### PR TITLE
[KDEV-63923] Deploy Stale Action [MASS PR]

### DIFF
--- a/.github/WORKFLOWS/stale.yml
+++ b/.github/WORKFLOWS/stale.yml
@@ -1,0 +1,49 @@
+  name: Stale
+  #mark and close stale prs. full documentation available here https://github.com/marketplace/actions/close-stale-issues
+  on:
+    workflow_dispatch: #this enables manual triggers
+    schedule:
+      - cron: "0 15 * * 1"
+  permissions:
+    pull-requests: write
+    contents: write # only for delete-branch option
+    issues: write
+  jobs:
+    stale:
+      name: stale check
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/stale@v9.0.0
+          with:
+            # Token for the repository. Can be passed in using `{{ secrets.GITHUB_TOKEN }}`.
+            repo-token: ${{ secrets.GITHUB_TOKEN }}
+            # The message to post on the pull request when tagging it. If none provided, will not mark pull requests stale.
+            stale-pr-message: This PR is stale because it has been open 30 days with no activity. Remove stale label or comment or this PR will be closed in 14 days. If this PR is still a WIP, please convert it to a draft PR add the DRAFT label so it will be ignored.
+            # The message to post on the pull request when closing it. If none provided, will not comment when closing a pull requests.
+            close-pr-message: "This PR was closed because it has been stale for 14 days with no activity. You can reopen the PR when it's ready for review."
+            # The number of days old a pull request can be before marking it stale. Set to -1 to never mark pull requests as stale automatically. Override "days-before-stale" option regarding only the pull requests.
+            days-before-pr-stale: 30
+            # The number of days to wait to close a pull request after it being marked stale. Set to -1 to never close stale pull requests. Override "days-before-close" option regarding only the pull requests.
+            days-before-pr-close: 13
+            # The label to apply when a pull request is stale.
+            stale-pr-label: Stale
+            # The label to apply when a pull request is closed.
+            close-pr-label: Stale-close
+            # The labels that mean a pull request is exempt from being marked as stale. Separate multiple labels with commas (eg. "label1,label2").
+            exempt-pr-labels: "DRAFT,dependencies,github_actions"
+            # The maximum number of operations per run, used to control rate limiting (GitHub API CRUD related).
+            operations-per-run: 30
+            # Remove stale labels from pull requests when they are updated or commented on. Override "remove-stale-when-updated" option regarding only the pull requests.
+            remove-pr-stale-when-updated: true 
+            # Run the processor in debug mode without actually performing any operations on live issues.
+            #debug-only: # optional, default is false
+            # Exempt draft pull requests from being marked as stale. Default to false.
+            exempt-draft-pr: false
+            # The order to get issues or pull requests. Defaults to false, which is descending.
+            ascending: false
+            # Delete the git branch after closing a stale pull request.
+            delete-branch: false
+            # The assignees which exempt a pull request from being marked as stale. Separate multiple assignees with commas (eg. "user1,user2"). Override "exempt-assignees" option regarding only the pull requests.
+            exempt-pr-assignees: "app/dependabot"
+            # Display some statistics at the end regarding the stale workflow (only when the logs are enabled).
+            enable-statistics: true


### PR DESCRIPTION
Deploy Stale GH Action to run once a week on Monday 11am ET + give the ability to run manually. Stale marks all PRS with the Stale label that are inactive for 30+ days and then 14 days later, closes the pr if there is no activity. PRs with the label dependencies,github_actions,Draft are ignored or if they are authored by Dependabot.